### PR TITLE
Use High Security Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Two application environment variables must be set in the `newrelic` app:
  * `application_name`: human readable name of the app, will show up in the web interface
  * `license_key`: secret license key
 
+One application environment variable is optional:
+ * `high_security`: whether to send the high_security param in POST
 
 ## Statman integration
 

--- a/src/newrelic.erl
+++ b/src/newrelic.erl
@@ -6,7 +6,7 @@
 % Exported for testing
 -export([sample_data/0, sample_error_data/0]).
 
--define(BASE_URL, "http://~s/agent_listener/invoke_raw_method?").
+-define(BASE_URL, "https://~s/agent_listener/invoke_raw_method?").
 
 -define(l2b(L), list_to_binary(L)).
 -define(l2i(L), list_to_integer(L)).
@@ -57,6 +57,7 @@ connect(Collector, Hostname) ->
               {pid, ?l2i(os:getpid())},
               {environment, []},
               {language, <<"python">>},
+              {high_security, [high_security()]},
               {settings, {[]}}
              ]}],
 
@@ -129,7 +130,9 @@ license_key() ->
     {ok, Key} = application:get_env(newrelic, license_key),
     Key.
 
-
+high_security() ->
+    {ok, Key} = application:get_env(newrelic, high_security),
+    string::equal(Key, <<"true">>).
 
 request(Url) ->
     request(Url, <<"[]">>).

--- a/src/newrelic.erl
+++ b/src/newrelic.erl
@@ -57,7 +57,7 @@ connect(Collector, Hostname) ->
               {pid, ?l2i(os:getpid())},
               {environment, []},
               {language, <<"python">>},
-              {high_security, [high_security()]},
+              {high_security, [true]},
               {settings, {[]}}
              ]}],
 
@@ -129,13 +129,6 @@ app_name() ->
 license_key() ->
     {ok, Key} = application:get_env(newrelic, license_key),
     Key.
-
-high_security() ->
-    Value = case application:get_env(newrelic, high_security) of
-      undefined   -> 'false';
-      {ok, V}     -> V
-    end.
-    string:equal(Value, <<"true">>).
 
 request(Url) ->
     request(Url, <<"[]">>).

--- a/src/newrelic.erl
+++ b/src/newrelic.erl
@@ -131,8 +131,11 @@ license_key() ->
     Key.
 
 high_security() ->
-    {ok, Key} = application:get_env(newrelic, high_security),
-    string:equal(Key, <<"true">>).
+    Value = case application:get_env(newrelic, high_security) of
+      undefined   -> 'false';
+      {ok, V}     -> V
+    end.
+    string:equal(Value, <<"true">>).
 
 request(Url) ->
     request(Url, <<"[]">>).

--- a/src/newrelic.erl
+++ b/src/newrelic.erl
@@ -132,7 +132,7 @@ license_key() ->
 
 high_security() ->
     {ok, Key} = application:get_env(newrelic, high_security),
-    string::equal(Key, <<"true">>).
+    string:equal(Key, <<"true">>).
 
 request(Url) ->
     request(Url, <<"[]">>).


### PR DESCRIPTION
This fixed an issue for us with high security mode (https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode).    

This adds an application environment variable that defaults to false for high_security.
